### PR TITLE
update docs to use the @action decorator

### DIFF
--- a/addon/modifiers/did-insert.js
+++ b/addon/modifiers/did-insert.js
@@ -22,22 +22,22 @@ import Ember from 'ember';
   ```
 
   By default, the executed function will be unbound. If you would like to access
-  the component context in your function, use the `action` helper as follows:
+  the component context in your function, use the `action` decorator as follows:
 
   ```handlebars
-  <div {{did-insert (action this.incrementCount)}}>first</div>
-  <div {{did-insert (action this.incrementCount)}}>second</div>
+  <div {{did-insert this.incrementCount}}>first</div>
+  <div {{did-insert this.incrementCount}}>second</div>
 
   <p>{{this.count}} elements were rendered</p>
   ```
 
-    ```js
+  ```js
   export default Component.extend({
-    @tracked count = 0;
+    count: tracked({ value: 0 }),
 
-    incrementCount() {
+    incrementCount: action(function() {
       this.count++;
-    }
+    })
   });
   ```
 

--- a/addon/modifiers/did-update.js
+++ b/addon/modifiers/did-update.js
@@ -39,10 +39,18 @@ import Ember from 'ember';
   ```
 
   By default, the executed function will be unbound. If you would like to access
-  the component context in your function, use the `action` helper as follows:
+  the component context in your function, use the `action` decorator as follows:
 
   ```handlebars
-  <div {{did-update (action this.someFunction) @someArg} />
+  <div {{did-update this.someFunction @someArg} />
+  ```
+
+  ```js
+  export default Component.extend({
+    someFunction: action(function(element, [someArg]) {
+      // the `this` context will be the component instance
+    })
+  });
   ```
 
   @method did-update

--- a/addon/modifiers/will-destroy.js
+++ b/addon/modifiers/will-destroy.js
@@ -19,12 +19,20 @@ import Ember from 'ember';
   ```
 
   By default, the executed function will be unbound. If you would like to access
-  the component context in your function, use the `action` helper as follows:
+  the component context in your function, use the `action` decorator as follows:
 
-    ```handlebars
-  <div {{will-destroy (action this.teardownPlugin)}}>
+  ```handlebars
+  <div {{will-destroy this.teardownPlugin}}>
     {{yield}}
   </div>
+  ```
+
+  ```js
+  export default Component.extend({
+    teardownPlugin: action(function(element) {
+      // the `this` context will be the component instance
+    })
+  });
   ```
 
   @method will-destroy


### PR DESCRIPTION
This updates the docs to use the `action` decorator instead of the classic `action` helper
