### PR TITLE
Disable modifier auto-tracking.

### DIFF
--- a/addon/modifiers/did-insert.js
+++ b/addon/modifiers/did-insert.js
@@ -46,7 +46,7 @@ import { setModifierManager, capabilities } from '@ember/modifier';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13'),
+    capabilities: capabilities('3.13', { disableAutoTracking: true }),
 
     createModifier() {},
 

--- a/addon/modifiers/did-update.js
+++ b/addon/modifiers/did-update.js
@@ -58,7 +58,7 @@ import { setModifierManager, capabilities } from '@ember/modifier';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13'),
+    capabilities: capabilities('3.13', { disableAutoTracking: true }),
 
     createModifier() {
       return { element: null };

--- a/addon/modifiers/will-destroy.js
+++ b/addon/modifiers/will-destroy.js
@@ -40,7 +40,7 @@ import { setModifierManager, capabilities } from '@ember/modifier';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13'),
+    capabilities: capabilities('3.13', { disableAutoTracking: true }),
 
     createModifier() {
       return { element: null };

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "github": {
       "release": true
     }
+  },
+  "resolutions": {
+    "**/engine.io": "~3.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,7 +3878,7 @@ engine.io-parser@~2.1.0, engine.io-parser@~2.1.1:
     blob "0.0.5"
     has-binary2 "~1.0.2"
 
-engine.io@~3.3.1:
+engine.io@~3.3.0, engine.io@~3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.3.2.tgz#18cbc8b6f36e9461c5c0f81df2b830de16058a59"
   integrity sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==


### PR DESCRIPTION
The original RFC specifically defines when these modifier methods should be called, and in all scenarios the semantics of when to re-fire (only applicable to `did-update`) exclude auto-tracking.

did-insert
----------
[From the RFC](https://github.com/emberjs/rfcs/blob/master/text/0415-render-element-modifiers.md#did-insert):

> This modifier is activated only when The element is inserted in the DOM.

did-update
----------

[From the RFC](https://github.com/emberjs/rfcs/blob/master/text/0415-render-element-modifiers.md#did-update):

> This modifier is activated only on updates to it's arguments (both positional and named). It does not run during or after initial render, or before element destruction.

will-destroy
------------

[From the RFC](https://github.com/emberjs/rfcs/blob/master/text/0415-render-element-modifiers.md#will-destroy)

> This modifier is activated:
>
> - immediately before the element is removed from the DOM.