### PR TITLE
Adding better errors when passing null or undefined to modifiers

### DIFF
--- a/addon/modifiers/did-insert.js
+++ b/addon/modifiers/did-insert.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 
 /**
@@ -54,11 +55,16 @@ export default setModifierManager(
       _state,
       element,
       {
-        positional: [fn, ...args],
+        positional: [didInsertFunction, ...args],
         named,
       }
     ) {
-      fn(element, args, named);
+      assert(
+        `You need to pass a function as the first argument to \`did-insert\` you passed ${didInsertFunction}`,
+        typeof didInsertFunction === 'function'
+      );
+
+      didInsertFunction(element, args, named);
     },
 
     updateModifier() {},

--- a/addon/modifiers/did-update.js
+++ b/addon/modifiers/did-update.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 
 /**
@@ -69,9 +70,14 @@ export default setModifierManager(
     },
 
     updateModifier({ element }, args) {
-      let [fn, ...positional] = args.positional;
+      let [didUpdateFunction, ...positional] = args.positional;
 
-      fn(element, positional, args.named);
+      assert(
+        `You need to pass a function as the first argument to \`did-update\` you passed ${didUpdateFunction}`,
+        typeof didUpdateFunction === 'function'
+      );
+
+      didUpdateFunction(element, positional, args.named);
     },
 
     destroyModifier() {},

--- a/addon/modifiers/will-destroy.js
+++ b/addon/modifiers/will-destroy.js
@@ -1,3 +1,4 @@
+import { assert } from '@ember/debug';
 import { setModifierManager, capabilities } from '@ember/modifier';
 
 /**
@@ -53,9 +54,14 @@ export default setModifierManager(
     updateModifier() {},
 
     destroyModifier({ element }, args) {
-      let [fn, ...positional] = args.positional;
+      let [willDestroyFunction, ...positional] = args.positional;
 
-      fn(element, positional, args.named);
+      assert(
+        `You need to pass a function as the first argument to \`will-destroy\` you passed ${willDestroyFunction}`,
+        typeof willDestroyFunction === 'function'
+      );
+
+      willDestroyFunction(element, positional, args.named);
     },
   }),
   class WillDestroyModifier {}

--- a/tests/integration/modifiers/did-insert-test.js
+++ b/tests/integration/modifiers/did-insert-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Component from '@ember/component';
 
@@ -75,5 +75,20 @@ module('Integration | Modifier | did-insert', function(hooks) {
     await render(hbs`{{sometimes-fades-in shouldShow=true}}`);
 
     assert.dom('.alert').hasClass('fade-in');
+  });
+
+  test('throws meaningful error when did-insert does not receive a function', async function(assert) {
+    assert.expect(1);
+
+    this.notAFunction = null;
+
+    setupOnerror(function(error) {
+      assert.equal(
+        error.message,
+        'Assertion Failed: You need to pass a function as the first argument to `did-insert` you passed null'
+      );
+    });
+
+    await render(hbs`<div {{did-insert this.notAFunction}}></div>`);
   });
 });

--- a/tests/integration/modifiers/did-update-test.js
+++ b/tests/integration/modifiers/did-update-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | did-update', function(hooks) {
@@ -22,6 +22,23 @@ module('Integration | Modifier | did-update', function(hooks) {
       hbs`<div data-foo="some-thing" {{did-update this.someMethod this.boundValue}}></div>`
     );
 
+    this.set('boundValue', 'update');
+  });
+
+  test('throws meaningful error when did-update does not receive a function', async function(assert) {
+    assert.expect(1);
+
+    this.notAFunction = null;
+    this.set('boundValue', 'initial');
+
+    setupOnerror(function(error) {
+      assert.equal(
+        error.message,
+        'Assertion Failed: You need to pass a function as the first argument to `did-update` you passed null'
+      );
+    });
+
+    await render(hbs`<div {{did-update this.notAFunction this.boundValue}}></div>`);
     this.set('boundValue', 'update');
   });
 });

--- a/tests/integration/modifiers/will-destroy-test.js
+++ b/tests/integration/modifiers/will-destroy-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | will-destroy', function(hooks) {
@@ -39,6 +39,25 @@ module('Integration | Modifier | will-destroy', function(hooks) {
     await render(
       hbs`{{#if show}}<div data-foo="some-thing" {{will-destroy this.someMethod "some-positional-value" some="hash-value"}}></div>{{/if}}`
     );
+
+    // trigger destroy
+    this.set('show', false);
+  });
+
+  test('throws meaningful error when will-destroy does not receive a function', async function(assert) {
+    assert.expect(2);
+
+    this.notAFunction = null;
+    this.set('show', true);
+
+    setupOnerror(function(error) {
+      assert.equal(
+        error.message,
+        'Assertion Failed: You need to pass a function as the first argument to `will-destroy` you passed null'
+      );
+    });
+
+    await render(hbs`{{#if show}}<div {{will-destroy this.notAFunction}}></div>{{/if}}`);
 
     // trigger destroy
     this.set('show', false);


### PR DESCRIPTION
- Asserts an error then the function passed to `did-insert`, `did-update` and `will-destroy` is not a function.

- Today the error is `fn must be a function` `fn` has another [meaning](https://api.emberjs.com/ember/3.27/classes/Ember.Templates.helpers/methods/fn?anchor=fn) in emberland.