### PR TITLE
Update manager capabilities to 3.22 to fix deprecation in Ember 3.26+

### DIFF
--- a/addon/modifiers/did-insert.js
+++ b/addon/modifiers/did-insert.js
@@ -1,4 +1,5 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
+import { gte } from 'ember-compatibility-helpers';
 
 /**
   The `{{did-insert}}` element modifier is activated when an element is
@@ -46,7 +47,7 @@ import { setModifierManager, capabilities } from '@ember/modifier';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13', { disableAutoTracking: true }),
+    capabilities: capabilities(gte('3.22.0') ? '3.22' : '3.13', { disableAutoTracking: true }),
 
     createModifier() {},
 

--- a/addon/modifiers/did-update.js
+++ b/addon/modifiers/did-update.js
@@ -1,4 +1,5 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
+import { gte } from 'ember-compatibility-helpers';
 
 /**
   The `{{did-update}}` element modifier is activated when any of its arguments
@@ -58,17 +59,35 @@ import { setModifierManager, capabilities } from '@ember/modifier';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13', { disableAutoTracking: true }),
+    capabilities: gte('3.22.0')
+      ? capabilities('3.22', { disableAutoTracking: false })
+      : capabilities('3.13', { disableAutoTracking: true }),
 
     createModifier() {
       return { element: null };
     },
-    installModifier(state, element) {
+    installModifier(state, element, args) {
       // save element into state bucket
       state.element = element;
+
+      if (gte('3.22.0')) {
+        // Consume individual properties to entangle tracking.
+        // https://github.com/emberjs/ember.js/issues/19277
+        // https://github.com/ember-modifier/ember-modifier/pull/63#issuecomment-815908201
+        args.positional.forEach(() => {});
+        args.named && Object.values(args.named);
+      }
     },
 
     updateModifier({ element }, args) {
+      if (gte('3.22.0')) {
+        // Consume individual properties to entangle tracking.
+        // https://github.com/emberjs/ember.js/issues/19277
+        // https://github.com/ember-modifier/ember-modifier/pull/63#issuecomment-815908201
+        args.positional.forEach(() => {});
+        args.named && Object.values(args.named);
+      }
+
       let [fn, ...positional] = args.positional;
 
       fn(element, positional, args.named);

--- a/addon/modifiers/will-destroy.js
+++ b/addon/modifiers/will-destroy.js
@@ -1,4 +1,5 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
+import { gte } from 'ember-compatibility-helpers';
 
 /**
   The `{{will-destroy}}` element modifier is activated immediately before the element
@@ -40,7 +41,7 @@ import { setModifierManager, capabilities } from '@ember/modifier';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities('3.13', { disableAutoTracking: true }),
+    capabilities: capabilities(gte('3.22.0') ? '3.22' : '3.13', { disableAutoTracking: true }),
 
     createModifier() {
       return { element: null };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
+    "ember-compatibility-helpers": "^1.2.5",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,7 +6427,7 @@ ember-cli@~3.27.0:
     workerpool "^6.0.3"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==


### PR DESCRIPTION
This takes over #33.

Note that release/beta/canary fail in `master` hence CI is not completely happy.

Created same PR in my fork to check CI and all tests pass (except release/beta/canary): https://github.com/SergeAstapov/ember-render-modifiers/pull/5/checks

In order to get release/beta pass, we need to land #40 by @kiwiupover first.
Created such PR in my fork to check CI and all tests pass except canary: https://github.com/SergeAstapov/ember-render-modifiers/pull/3/checks?check_run_id=3748714875

The issue we get on canary is
```
Error: To use these addons, your app needs ember-auto-import >= 2: ember-source
```