### PR TITLE
Fix deprecations in tests

### DIFF
--- a/tests/integration/modifiers/will-destroy-test.js
+++ b/tests/integration/modifiers/will-destroy-test.js
@@ -16,7 +16,7 @@ module('Integration | Modifier | will-destroy', function (hooks) {
     this.set('show', true);
 
     await render(
-      hbs`{{#if show}}<div data-foo="some-thing" {{will-destroy this.someMethod}}></div>{{/if}}`
+      hbs`{{#if this.show}}<div data-foo="some-thing" {{will-destroy this.someMethod}}></div>{{/if}}`
     );
 
     // trigger destroy
@@ -37,7 +37,7 @@ module('Integration | Modifier | will-destroy', function (hooks) {
     this.set('show', true);
 
     await render(
-      hbs`{{#if show}}<div data-foo="some-thing" {{will-destroy this.someMethod "some-positional-value" some="hash-value"}}></div>{{/if}}`
+      hbs`{{#if this.show}}<div data-foo="some-thing" {{will-destroy this.someMethod "some-positional-value" some="hash-value"}}></div>{{/if}}`
     );
 
     // trigger destroy

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,7 +4,6 @@ import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import { start } from 'ember-qunit';
-import { assign } from '@ember/polyfills';
 
 setApplication(Application.create(config.APP));
 
@@ -15,7 +14,7 @@ start();
 QUnit.assert.namedArgsEqual = function (actual, expected, message) {
   // this is needed because older versions of Ember pass an `EmptyObject`
   // based object and QUnit fails due to the prototypes not matching
-  let sanitizedActual = assign({}, actual);
+  let sanitizedActual = Object.assign({}, actual);
 
   this.deepEqual(sanitizedActual, expected, message);
 };


### PR DESCRIPTION
This fixes `ember-polyfills.deprecate-assign` and `this-property-fallback` deprecations during tests run