### PR TITLE
build: move ember-auto-import to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "ember-auto-import": "^2.2.0",
     "ember-cli-babel": "^7.26.6",
     "ember-compatibility-helpers": "^1.2.5",
     "ember-modifier-manager-polyfill": "^1.2.0"
@@ -38,7 +39,6 @@
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
-    "ember-auto-import": "^2.2.0",
     "ember-cli": "~3.28.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^5.7.1",


### PR DESCRIPTION
Move [ember-auto-import](https://github.com/ef4/ember-auto-import) from devDeps to dependencies, as specified in https://github.com/ef4/ember-auto-import/tree/main/packages/ember-auto-import#installing-ember-auto-import-in-an-addon

It may be "breaking" because projects consuming `ember-render-modifiers` will have to upgrade to `ember-auto-import@2` (see [migration guide](https://github.com/ef4/ember-auto-import/blob/main/docs/upgrade-guide-2.0.md#quick-summary))

(Making this PR because we upgraded `ember-render-modifiers` in an application using `ember-auto-import@1` and we were surprised to not have `ember-auto-import` errors as we noticed in the changelog that `ember-render-modifiers` use V2 ; note that in the other hand our app is working correctly, so this PR is just here to match ember-auto-import readme regarding implementation on addons)