### PR TITLE
Fix README information clarifying the purpose of `ember-render-modifiers` 

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019
+Copyright (c) 2021
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Other times, you may find that a modifier is not the right fit for that logic at
 in which case it's worth revisiting the design to find a better pattern.
 
 Either way, we recommend using these modifiers with caution. They are very useful for
-quickly bridging the gap between classic components and Glimmer components, but they
-are still generally an anti-pattern. We recommend considering a custom modifier in
-most use-cases where you might want to reach for this package.
+quickly bridging the gap between classic components and Glimmer components. We recommend considering a custom modifier in most use-cases where you might want to reach for this package.
 
 ## Compatibility
 


### PR DESCRIPTION
I've been using this addon for 2 years not just for migrating old ember apps to octane way, but for some cases that we need modifiers we can use this addon as a useful library to provide a `this.element` into glimmer component when I have to wait for the element inserted into the DOM. In some cases, we don't want to create a global modifier (because modifiers are global as helpers on the Ember ecosystem) to get some HTML element into the component. 

I know this package was created with the purpose to solve some gaps and speed the migration of classic components to glimmer components, but over time it showed very ergonomic when your component require some DOM manipulation.

In this example below, I have to prevent that click on `<li/>` children created by `submenu` start to propagate `click` on `<li/>`.  could I create a modifier? clear! But this addon made it more explicit that I'm waiting for a "did-insert" event and there I have a more readable and flexible code that allows us to manipulate the dom several times without needing to do a premature abstraction creating several modifiers. That's why shouldn't consider anymore it's generally an anti-pattern and put fear in those who read the readme

```hbs
<li
  local-class="nav-item submenu"
  class="nav-item"
  role="button"
  {{on "click" this.handleClick}}
  {{did-insert (set this "anchorElement")}}
>
  {{yield (hash
    submenu=(component 'nav-bar/submenu' isOpen=this.isOpen)
  )}}
</li>
```

```ts
import Component from '@glimmer/component'
import { tracked } from '@glimmer/tracking'
import { action } from '@ember/object'

export default class ItemComponent extends Component {
  @tracked isOpen = false
  @tracked anchorElement!: HTMLAnchorElement

  @action
  handleClick (event: MouseEvent): void {
    if (event.target !== this.anchorElement) {
      return
    }
    this.isOpen = !this.isOpen
  }
}
```

 