### PR TITLE
Fully migrate to @embroider/macros

### DIFF
--- a/addon/modifiers/did-insert.js
+++ b/addon/modifiers/did-insert.js
@@ -1,5 +1,5 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
-import { gte } from 'ember-compatibility-helpers';
+import { macroCondition, dependencySatisfies } from '@embroider/macros';
 
 /**
   The `{{did-insert}}` element modifier is activated when an element is
@@ -47,7 +47,10 @@ import { gte } from 'ember-compatibility-helpers';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities(gte('3.22.0') ? '3.22' : '3.13', { disableAutoTracking: true }),
+    capabilities: capabilities(
+      macroCondition(dependencySatisfies('ember-source', '>= 3.22.0-beta.1')) ? '3.22' : '3.13',
+      { disableAutoTracking: true }
+    ),
 
     createModifier() {},
 

--- a/addon/modifiers/will-destroy.js
+++ b/addon/modifiers/will-destroy.js
@@ -1,5 +1,5 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
-import { gte } from 'ember-compatibility-helpers';
+import { macroCondition, dependencySatisfies } from '@embroider/macros';
 
 /**
   The `{{will-destroy}}` element modifier is activated immediately before the element
@@ -41,7 +41,10 @@ import { gte } from 'ember-compatibility-helpers';
 */
 export default setModifierManager(
   () => ({
-    capabilities: capabilities(gte('3.22.0') ? '3.22' : '3.13', { disableAutoTracking: true }),
+    capabilities: capabilities(
+      macroCondition(dependencySatisfies('ember-source', '>= 3.22.0-beta.1')) ? '3.22' : '3.13',
+      { disableAutoTracking: true }
+    ),
 
     createModifier() {
       return { element: null };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@embroider/macros": ">= 0.48.1 < 2.0.0-alpha.1",
     "ember-cli-babel": "^7.26.6",
-    "ember-compatibility-helpers": "^1.2.5",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6578,7 +6578,7 @@ ember-cli@~3.28.0:
     workerpool "^6.1.4"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==


### PR DESCRIPTION
Removes remaining ember-compatibility-helpers usages, and removes the
dependency.
