### PR TITLE
Relax ember-source peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || 4"
+    "ember-source": "^3.8 || ^4.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
Currently the peer dependency is `^3.8 || 4` which I guess does not cover e.g. `4.1.0`?