### PR TITLE
Loosen `peerDependencies` requirement for `ember-source`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ most use-cases where you might want to reach for this package.
 
 ## Compatibility
 
-- Ember.js v3.20 or above
+- Ember.js v3.8 or above
 - Ember CLI v3.20 or above
 - Node.js v12 or above
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || 4"
+    "ember-source": "*"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"
@@ -83,7 +83,10 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "versionCompatibility": {
+      "ember": ">=3.8"
+    }
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
Using `peerDependencies` with specific versions range may cause issues in monorepo setup when ember-source versions don't match and the wrong one may be hoisted to the top.

This caused problems when tried to port `ember-animated` to v2 in https://github.com/ember-animation/ember-animated/pull/388:
when running `ember-try` 3.20 ember-try scenario, yarn/npm as well as pnpm hoisted `ember-source@4` to the top level and as a result `@emberoider/utils` detect v4.1 when the test-app actually used 3.20.

As far as I understand, there is no benefit having specific version(s) listed in `peerDependencies` as it may force package manager install extra `ember-source` in addition to `ember-source` used by host app and it's not needed for this addon to function.

Supersedes #61 cc @mydea