### PR TITLE
Add link to video with examples of how to migrate away

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ most use-cases where you might want to reach for this package.
 _**For more information on why these modifiers exist and concrete examples of what the modern alternatives to using them are,
 watch the below talk from EmberFest 2022.**_
 
-<a href="https://www.youtube.com/watch?v=zwewg2xmpU8">
-  <img src="https://user-images.githubusercontent.com/416724/195643386-e4076f35-56f6-4244-aae0-0a02f936f952.png">
-</a>
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=zwewg2xmpU8">
+    <img width="460" src="https://user-images.githubusercontent.com/416724/195643386-e4076f35-56f6-4244-aae0-0a02f936f952.png">
+  </a>
+</p>
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ quickly bridging the gap between classic components and Glimmer components, but 
 are still generally an anti-pattern. We recommend considering a custom modifier in
 most use-cases where you might want to reach for this package.
 
+_**For more information on why these modifiers exist and concrete examples of what the modern alternatives to using them are,
+watch the below talk from EmberFest 2022.**_
+
+<a href="https://www.youtube.com/watch?v=zwewg2xmpU8">
+  <img src="https://user-images.githubusercontent.com/416724/195643386-e4076f35-56f6-4244-aae0-0a02f936f952.png">
+</a>
+
 ## Compatibility
 
 - Ember.js v3.20 or above


### PR DESCRIPTION
[RENDERED](https://github.com/achambers/ember-render-modifiers/blob/patch-1/README.md)

I recently gave a talk at EmberFest to describe the rationale and history of these modifiers, why they are considered an anti-pattern today and, most importantly, what the alternatives are for migrating away from them using concrete examples.

This talk is the culmination of many conversations and pairing sessions with engineers educating them on this info which they don't get from the README, so this seems like the perfect place to link to the talk.