### PR TITLE
Widen peer range for ember-source to include all of v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || 4"
+    "ember-source": "^3.8 || ^4.0.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
🤷 

Noticed with @rwwagner90 that in a pnpm monorepo, we're falling in to the 3.13 branch of https://github.com/emberjs/ember-render-modifiers/blob/master/addon/modifiers/did-insert.js#L51