### PR TITLE
Add ember-source v5 to peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || ^4.0.0"
+    "ember-source": "^3.8 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"


### PR DESCRIPTION
While `@ember/render-modifiers` presently does not have anything deprecated[^1] for removal in ember-source v5, I figure it'd be good to add v5 to the peer list.


[^1]: There is private api usage though, but I don't see that getting removed in v5 either