### PR TITLE
Introduce type definitions for render modifiers

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -23,3 +23,6 @@
 /package.json.ember-try
 /package-lock.json.ember-try
 /yarn.lock.ember-try
+
+# types
+/types/

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@embroider/util": "^1.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@glint/template": "^1.0.2",
     "babel-eslint": "^10.1.0",
     "ember-auto-import": "^2.2.4",
     "ember-cli": "~4.1.0",
@@ -71,7 +72,13 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || ^4.0.0 || ^5.0.0"
+    "ember-source": "^3.8 || ^4.0.0 || ^5.0.0",
+    "@glint/template": "^1.0.2"
+  },
+  "peerDependenciesMeta": {
+    "@glint/template": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "12.* || 14.* || >= 16"
@@ -98,6 +105,13 @@
     },
     "github": {
       "release": true
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "types/*"
+      ]
     }
   }
 }

--- a/types/-private.d.ts
+++ b/types/-private.d.ts
@@ -1,0 +1,8 @@
+export interface RenderModifierSignature<El extends Element, Args extends Array<any>> {
+  Args: {
+    Positional: [
+      callback: (element: El, ...args: Args) => unknown,
+      ...callbackArgs: Args
+    ];
+  };
+}

--- a/types/modifiers/did-insert.d.ts
+++ b/types/modifiers/did-insert.d.ts
@@ -1,0 +1,9 @@
+import { ModifierLike } from '@glint/template';
+import { RenderModifierSignature } from '../-private';
+
+declare const didInsert: abstract new <
+  El extends Element,
+  Args extends Array<any>
+>() => InstanceType<ModifierLike<RenderModifierSignature<El, Args>>>;
+
+export default didInsert;

--- a/types/modifiers/did-update.d.ts
+++ b/types/modifiers/did-update.d.ts
@@ -1,0 +1,9 @@
+import { ModifierLike } from '@glint/template';
+import { RenderModifierSignature } from '../-private';
+
+declare const didUpdate: abstract new <
+  El extends Element,
+  Args extends Array<any>
+>() => InstanceType<ModifierLike<RenderModifierSignature<El, Args>>>;
+
+export default didUpdate;

--- a/types/modifiers/will-destroy.d.ts
+++ b/types/modifiers/will-destroy.d.ts
@@ -1,0 +1,9 @@
+import { ModifierLike } from '@glint/template';
+import { RenderModifierSignature } from '../-private';
+
+declare const willDestroy: abstract new <
+  El extends Element,
+  Args extends Array<any>
+>() => InstanceType<ModifierLike<RenderModifierSignature<El, Args>>>;
+
+export default willDestroy;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,6 +1494,11 @@
     "@glimmer/interfaces" "^0.42.2"
     "@glimmer/util" "^0.42.2"
 
+"@glint/template@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@glint/template/-/template-1.0.2.tgz#dcb96f048df52e7d0e78cf194fa07b3c42f15278"
+  integrity sha512-kFWfJrS7XM0NjC5YSN0CWA9FiN0mhUvWVlQ2O7YRz/uhrO8+TVYNLst0WKELRbfCXbdI7wyYQkazNgz6FoL9CA==
+
 "@handlebars/parser@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"


### PR DESCRIPTION
Since these are not actively recommended, I am not taking the time to actively reimplement the package as TypeScript, but we *do* need types for these in the ecosystem. These use `@glint/template` as a peer and dev dependencies, and supply custom generic types using `ModifierLike` rather than using the types from `ember-modifier` since these modifiers use custom modifier managers instead.