### PR TITLE
Add Ember v6 to Peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || ^4.0.0 || ^5.0.0",
+    "ember-source": "^3.8 || >= 4.0.0",
     "@glint/template": "^1.0.2"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Newly [released](https://github.com/emberjs/ember.js/releases/tag/v6.0.0-ember-source) and ready for use!

Could also be updated to match the current ember-cli blueprint of `"ember-source": ">= 4.0.0"`, but would then drop support for 3.8 so I went with this instead.