### PR TITLE
chore: make release-able by fixing `repository` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "git@github.com:emberjs/ember-render-modifiers.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/emberjs/ember-render-modifiers.git"
+  },
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue>",
   "main": "index.js",


### PR DESCRIPTION
Without this:

```
ERROR npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
```

Doing so results in this change.