### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "dependencies": {
     "@babel/core": "^7.25.2",
     "@embroider/macros": "^1.0.0",
-    "ember-cli-babel": "^8.2.0",
-    "ember-modifier-manager-polyfill": "^1.2.0"
+    "ember-cli-babel": "^8.2.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.1",


### PR DESCRIPTION
This dependency is now inert, and causes issues.

inert because the current blueprint of this addon says it support 4.12 onwards-- and that dependency says its inert 3.8 onwards.

Still, that dep relies on an outdated ember-cli-version-checker version.

My 2 cents: no longer needed.